### PR TITLE
Update to latest master and enable RTSP video streaming

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,11 @@ FROM ubuntu:18.04
 
 ENV WORKSPACE_DIR /root
 ENV FIRMWARE_DIR ${WORKSPACE_DIR}/Firmware
+ENV SITL_RTSP_PROXY ${WORKSPACE_DIR}/sitl_rtsp_proxy
 
 ENV DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
+ENV DISPLAY :99
+ENV LANG C.UTF-8
 
 RUN apt-get update && \
     apt-get install -y bc \
@@ -14,23 +17,31 @@ RUN apt-get update && \
                        libopencv-dev \
                        libroscpp-dev \
                        protobuf-compiler \
-                       python-empy \
-                       python-jinja2 \
-                       python-numpy \
-                       python-toml \
-                       python-yaml \
+                       python3-pip \
                        unzip \
                        gazebo9 \
                        libgazebo9-dev \
+                       gstreamer1.0-plugins-bad \
                        gstreamer1.0-plugins-base \
                        gstreamer1.0-plugins-good \
-                       libgstreamer-plugins-base1.0-dev && \
+                       gstreamer1.0-plugins-ugly \
+                       libgstreamer-plugins-base1.0-dev \
+                       libgstrtspserver-1.0-dev \
+                       xvfb && \
     apt-get -y autoremove && \
     apt-get clean autoclean && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
+RUN pip3 install empy \
+                 jinja2 \
+                 numpy \
+                 packaging \
+                 pyros-genmsg \
+                 toml \
+                 pyyaml
+
 RUN git clone https://github.com/PX4/Firmware.git ${FIRMWARE_DIR}
-RUN git -C ${FIRMWARE_DIR} checkout stable
+RUN git -C ${FIRMWARE_DIR} checkout master
 RUN git -C ${FIRMWARE_DIR} submodule update --init --recursive
 
 COPY edit_rcS.bash ${WORKSPACE_DIR}
@@ -42,5 +53,9 @@ RUN ["/bin/bash", "-c", " \
     DONT_RUN=1 make px4_sitl gazebo && \
     DONT_RUN=1 make px4_sitl gazebo \
 "]
+
+COPY sitl_rtsp_proxy ${SITL_RTSP_PROXY}
+RUN cmake -B${SITL_RTSP_PROXY}/build -H${SITL_RTSP_PROXY}
+RUN cmake --build ${SITL_RTSP_PROXY}/build
 
 ENTRYPOINT ["/root/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+Xvfb :99 -screen 0 1600x1200x24+32 &
+${SITL_RTSP_PROXY}/build/sitl_rtsp_proxy &
+
 source ${WORKSPACE_DIR}/edit_rcS.bash $1 $2 &&
 cd ${FIRMWARE_DIR} &&
-HEADLESS=1 make px4_sitl gazebo
+HEADLESS=1 make px4_sitl gazebo_typhoon_h480

--- a/sitl_rtsp_proxy/CMakeLists.txt
+++ b/sitl_rtsp_proxy/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.10)
+
+set(CMAKE_CXX_STANDARD 11)
+
+project(SitlRtspProxy)
+
+add_definitions("-std=c++11 -Wall -Wextra -Werror")
+
+find_package(PkgConfig)
+pkg_check_modules(GST REQUIRED gstreamer-1.0>=1.4 gstreamer-rtsp-server-1.0>=1.4)
+
+add_executable(sitl_rtsp_proxy main.cpp)
+
+target_include_directories(sitl_rtsp_proxy SYSTEM PRIVATE
+    ${GST_INCLUDE_DIRS}
+)
+
+target_link_libraries(sitl_rtsp_proxy
+    ${GST_LIBRARIES}
+)

--- a/sitl_rtsp_proxy/main.cpp
+++ b/sitl_rtsp_proxy/main.cpp
@@ -1,0 +1,26 @@
+#include <gst/gst.h>
+#include <gst/rtsp-server/rtsp-server.h>
+#include <iostream>
+#include <string>
+
+int main(int argc, char* argv[]) {
+    gst_init(&argc, &argv);
+
+    GMainLoop* main_loop = g_main_loop_new(NULL, false);
+
+    GstRTSPServer* server = gst_rtsp_server_new();
+    g_object_set(server, "service", "8554", NULL);
+
+    std::string launch_string = "udpsrc port=5600 caps=application/x-rtp,encoding-name=(string)H264 ! rtph264depay ! rtph264pay name=pay0";
+    GstRTSPMediaFactory* factory = gst_rtsp_media_factory_new();
+    gst_rtsp_media_factory_set_launch(factory, launch_string.c_str());
+    gst_rtsp_media_factory_set_shared(factory, true);
+
+    GstRTSPMountPoints* mount_points = gst_rtsp_server_get_mount_points(server);
+    gst_rtsp_mount_points_add_factory(mount_points, "/live", factory);
+    g_object_unref(mount_points);
+
+    gst_rtsp_server_attach(server, NULL);
+
+    g_main_loop_run(main_loop);
+}


### PR DESCRIPTION
* Update to master
* Enable video streaming (default to running gazebo_typhoon_h480)
* Run Xvfb in the background (required for video streaming, thanks @mrivi :wink:)
* Run a gstreamer RTP-to-RTSP proxy to expose the video stream over RTSP
  on port 8554

As a result, one can now just expose port 8554 and access it from the host, e.g.:

```
docker run --rm -it -p 8554:8554 jonasvautherin/px4-gazebo-headless:latest
```

And then access it from VLC:

```
vlc rtsp://127.0.0.1:8554/live
```

@julianoes @Jaeyoung-Lim: FYI. Once merged into `master`, this will automatically generate `jonasvautherin/px4-gazebo-headless:latest` on docker hub. I'm planning to add some options later like choosing the drone (iris vs typhoon h480), and why not the world :blush:?