### PR TITLE
Fix rcS path for firmware update

### DIFF
--- a/edit_rcS.bash
+++ b/edit_rcS.bash
@@ -45,7 +45,7 @@ if is_docker_vm; then
     API_PARAM=${API_PARAM:-"-t ${VM_HOST}"}
 fi
 
-CONFIG_FILE=${FIRMWARE_DIR}/ROMFS/px4fmu_common/init.d-posix/rcS
+CONFIG_FILE=${FIRMWARE_DIR}/build/px4_sitl_default/etc/init.d-posix/rcS
 
 sed -i "s/mavlink start \-x \-u \$udp_gcs_port_local -r 4000000/mavlink start -x -u \$udp_gcs_port_local -r 4000000 ${QGC_PARAM}/" ${CONFIG_FILE}
 sed -i "s/mavlink start \-x \-u \$udp_offboard_port_local -r 4000000 -m onboard -o \$udp_offboard_port_remote/mavlink start -x -u \$udp_offboard_port_local -r 4000000 -o \$udp_offboard_port_remote ${API_PARAM}/" ${CONFIG_FILE}


### PR DESCRIPTION
**Problem Description**
After https://github.com/PX4/Firmware/pull/15714, the rcS that was being used was copied into the build directory at build time. Therefore modifying the rcS in the source doesn't modify the behavior of the simulation.

**Solution**
This commit is required to handle the latest firmware update since the rcS are copied into the build directory at build, therefore the rcS that is modified needs to be inside the build directory
