### PR TITLE
Raspberry Pi support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,14 +27,14 @@ RUN apt-get update && \
                        gstreamer1.0-plugins-ugly \
                        libgstreamer-plugins-base1.0-dev \
                        libgstrtspserver-1.0-dev \
-                       xvfb && \
+                       xvfb \
+                       numpy && \
     apt-get -y autoremove && \
     apt-get clean autoclean && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
 RUN pip3 install empy \
                  jinja2 \
-                 numpy \
                  packaging \
                  pyros-genmsg \
                  toml \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get update && \
                        libgstreamer-plugins-base1.0-dev \
                        libgstrtspserver-1.0-dev \
                        xvfb \
-                       numpy && \
+                       python3-numpy && \
     apt-get -y autoremove && \
     apt-get clean autoclean && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*


### PR DESCRIPTION
I tried to build the container based on the Readme instructions Manual build section but noticed that the Docker build fails on the `numpy` installation.
Installing `python3-numpy` through apt-get instead of `numpy` through pip3 fixes the issue.
Testing was limited to running and connecting the container to a QGroundControl instance running on a different PC over a local network.