### PR TITLE
ARM64 builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,43 +2,54 @@ name: Publish Docker
 on:
   push:
     branches:
-    - 'master'
+      - 'master'
     tags:
-    - 'v*'
+      - 'v*'
   pull_request:
     branches:
-    - '*'
+      - '*'
 
 jobs:
-  build-pr:
+  main:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
     steps:
-    - uses: actions/checkout@master
-    - name: Build
-      run: docker build .
-
-  publish-latest:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
-    steps:
-    - uses: actions/checkout@master
-    - name: Publish to Registry
-      uses: HurricanKai/Publish-Docker-Github-Action@master
-      with:
-        name: jonasvautherin/px4-gazebo-headless
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_TOKEN }}
-
-  publish-tag:
-    runs-on: ubuntu-latest
-    if: contains(github.ref, 'refs/tags/')
-    steps:
-    - uses: actions/checkout@master
-    - name: Publish to Registry
-      uses: HurricanKai/Publish-Docker-Github-Action@master
-      with:
-        name: jonasvautherin/px4-gazebo-headless
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_TOKEN }}
-        tagging: true
+      # Checkout repository
+      - uses: actions/checkout@master
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+      # https://github.com/marketplace/actions/docker-login
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+      # https://github.com/marketplace/actions/docker-metadata-action
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            jonasvautherin/px4-gazebo-headless
+          # Configure tags:
+          #   `master` branch -> `latest`
+          #   `v{xx.yy.zz}` tag -> `{xx.yy.zz}`
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=semver,pattern={{version}}
+      # https://github.com/marketplace/actions/build-and-push-docker-images
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          # Supported platforms
+          platforms: linux/amd64,linux/arm64/v8
+          # Do not push for pull requests
+          push: ${{ github.event_name != 'pull_request' }}
+          # Tags and labels defined in `meta` step
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,8 @@ RUN apt-get update && \
     apt-get clean autoclean && \
     rm -rf /var/lib/apt/lists/{apt,dpkg,cache,log} /tmp/* /var/tmp/*
 
-RUN pip3 install empy \
+RUN pip3 install --upgrade pip && \
+    pip3 install empy \
                  future \
                  jinja2 \
                  kconfiglib \
@@ -45,7 +46,7 @@ RUN pip3 install empy \
                  pyyaml
 
 RUN git clone https://github.com/PX4/PX4-Autopilot.git ${FIRMWARE_DIR}
-RUN git -C ${FIRMWARE_DIR} checkout master
+RUN git -C ${FIRMWARE_DIR} checkout main
 RUN git -C ${FIRMWARE_DIR} submodule update --init --recursive
 
 COPY edit_rcS.bash ${WORKSPACE_DIR}


### PR DESCRIPTION
Adds multi arch builds according to [this](https://dev.to/cloudx/multi-arch-docker-images-the-easy-way-with-github-actions-4k54) (corresponds to official Docker suggestions for QUEMU/buildx).

Additionally fixes:
- Main branch of `PX4-Autopilot` is now `main`, not `master`
- Upgrades PIP (prerequisite for multi-arch builds)

Resolves #26 