### PR TITLE
Enable passing hostnames instead of IPs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 function show_help {
     echo ""
-    echo "Usage: ${0} [-h | -v VEHICLE | -w WORLD] [IP_API | IP_QGC IP_API]"
+    echo "Usage: ${0} [-h | -v VEHICLE | -w WORLD] [HOST_API | HOST_QGC HOST_API]"
     echo ""
     echo "Run a headless px4-gazebo simulation in a docker container. The"
     echo "available vehicles and worlds are the ones available in PX4"
@@ -12,10 +12,22 @@ function show_help {
     echo "  -v    Set the vehicle (default: iris)"
     echo "  -w    Set the world (default: empty)"
     echo ""
-    echo "  <IP_API> is the IP to which PX4 will send MAVLink on UDP port 14540"
-    echo "  <IP_QGC> is the IP to which PX4 will send MAVLink on UDP port 14550"
+    echo "  <HOST_API> is the host or IP to which PX4 will send MAVLink on UDP port 14540"
+    echo "  <HOST_QGC> is the host or IP to which PX4 will send MAVLink on UDP port 14550"
     echo ""
     echo "By default, MAVLink is sent to the host."
+}
+
+function get_ip {
+    output=$(getent hosts "$1" | awk '{print $1}')
+    if [ -z $output ];
+    then
+        # No output, assume IP
+        echo $1
+    else
+        # Got IP, use it
+        echo $output
+    fi
 }
 
 OPTIND=1 # Reset in case getopts has been used previously in the shell.
@@ -38,22 +50,12 @@ done
 
 shift $((OPTIND-1))
 
-# All the leftover arguments are supposed to be IPs
-for arg in "$@"
-do
-    if ! [[ ${arg} =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        echo "Error: invalid IP: ${arg}!"
-        echo ""
-        show_help
-        exit 1
-    fi
-done
 
 if [ "$#" -eq 1 ]; then
-    IP_QGC="$1"
+    IP_QGC=$(get_ip "$1")
 elif [ "$#" -eq 2 ]; then
-    IP_API="$1"
-    IP_QGC="$2"
+    IP_API=$(get_ip "$1")
+    IP_QGC=$(get_ip "$2")
 elif [ "$#" -gt 2 ]; then
     show_help
     exit 1;


### PR DESCRIPTION
We can use `getent hosts` and `awk` to figure out the IP from a hostname. This is helpful when using the docker image as part of a docker compose setup with bridge network instead of host network.

Closes #30.