### PR TITLE
Replace sed with awk

### DIFF
--- a/edit_rcS.bash
+++ b/edit_rcS.bash
@@ -55,5 +55,12 @@ fi
 
 CONFIG_FILE=${FIRMWARE_DIR}/build/px4_sitl_default/etc/init.d-posix/px4-rc.mavlink
 
-sed -i "s/mavlink start \-x \-u \$udp_gcs_port_local -r 4000000/mavlink start -x -u \$udp_gcs_port_local -r 4000000 ${QGC_PARAM}/" ${CONFIG_FILE}
-sed -i "s/mavlink start \-x \-u \$udp_offboard_port_local -r 4000000/mavlink start -x -u \$udp_offboard_port_local -r 4000000 ${API_PARAM}/" ${CONFIG_FILE}
+awk -v qgc="${QGC_PARAM}" -v api="${API_PARAM}" '
+    /mavlink start -x -u \$udp_gcs_port_local -r 4000000/ { 
+        print $0" "qgc; next 
+    }
+    /mavlink start -x -u \$udp_offboard_port_local -r 4000000/ { 
+        print $0" "api; next 
+    }
+    { print }
+' "${CONFIG_FILE}" > "${CONFIG_FILE}.tmp" && mv "${CONFIG_FILE}.tmp" "${CONFIG_FILE}"

--- a/edit_rcS.bash
+++ b/edit_rcS.bash
@@ -10,7 +10,7 @@ function is_ip_valid {
 }
 
 function is_docker_vm {
-    getent hosts host.docker.internal >/dev/null 2>&1
+    getent ahostsv4 host.docker.internal >/dev/null 2>&1
     return $?
 }
 
@@ -20,7 +20,7 @@ function get_vm_host_ip {
         exit 1
     fi
 
-    echo "$(getent hosts host.docker.internal | awk '{ print $1 }')"
+    echo "$(getent ahostsv4 host.docker.internal | awk '{ print $1 }')"
 }
 
 function get_host_ip {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -19,7 +19,7 @@ function show_help {
 }
 
 function get_ip {
-    output=$(getent hosts "$1" | awk '{print $1}')
+    output=$(getent ahostsv4 "$1" | awk '{print $1}')
     if [ -z $output ];
     then
         # No output, assume IP


### PR DESCRIPTION
Not sure what has caused it, might be the ubuntu 20.04. But I keep getting follow error when starting the docker:

sed: -e expression #1, char 123: unterminated s' command
sed: -e expression #1, char 133: unterminated s' command

I tried altering the delimiter, but I was not able to find a solution that used sed. But I got it working with awk.